### PR TITLE
Make it possible to do extra initialization on resulting image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,36 @@
-FROM mysql:latest as builder
+FROM mysql:5 as builder
 
-# That file does the DB initialization but also runs mysql daemon, by removing the last line it will only init
-RUN ["sed", "-i", "s/exec \"$@\"/echo \"not running $@\"/", "/usr/local/bin/docker-entrypoint.sh"]
+# A an alternative entrypoint sourced from the original
+COPY entrypoint.sh /preloader_entrypoint.sh
+RUN chmod +x /preloader_entrypoint.sh
+ENTRYPOINT ["/preloader_entrypoint.sh"]
 
 # needed for intialization
-ENV MYSQL_ROOT_PASSWORD=root
+ENV MYSQL_DATABASE app
+ENV MYSQL_ROOT_PASSWORD=rootpass
+ENV MYSQL_USER 'user'
+ENV MYSQL_PASSWORD 'pass'
+# set DONT_START_MYSQLD so that we can run it without starting the daemon
+ENV DONT_START_MYSQLD 'true'
 
-COPY setup.sql /docker-entrypoint-initdb.d/
+COPY init_db/. /docker-entrypoint-initdb.d/.
 
 # Need to change the datadir to something else that /var/lib/mysql because the parent docker file defines it as a volume.
 # https://docs.docker.com/engine/reference/builder/#volume :
 #       Changing the volume from within the Dockerfile: If any build steps change the data within the volume after
 #       it has been declared, those changes will be discarded.
-RUN ["/usr/local/bin/docker-entrypoint.sh", "mysqld", "--datadir", "/initialized-db"]
+RUN ["./preloader_entrypoint.sh", "mysqld", "--datadir", "/initialized-db"]
 
-FROM mysql:latest
+
+FROM mysql:5
+
+ENTRYPOINT ["/preloader_entrypoint.sh"]
+ENV MYSQL_DATABASE app
+ENV MYSQL_ROOT_PASSWORD=rootpass
+ENV MYSQL_USER 'user'
+ENV MYSQL_PASSWORD 'pass'
+COPY entrypoint.sh /preloader_entrypoint.sh
+RUN chmod +x /preloader_entrypoint.sh
+
 
 COPY --from=builder /initialized-db /var/lib/mysql
-
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ see `Initializing a fresh instance` @ https://hub.docker.com/_/mysql/
 
 So let's run this initialization in a multi-stage build and copy the initialized DB in the new image :D
 
-(see comments in dockerfile for details of the hack) 
+(see comments in dockerfile for details of the hack)
 
 Try it!
 ======
@@ -44,3 +44,9 @@ Clone this, then...
 | Dolly   |
 +---------+
 ```
+
+additional sql can be initialised with the resulting image,
+via mounting sql files into /docker-entrypoint-initdb.d
+or preloading the generated image in the same way, using the previous image as a base
+>docker run -it --mount type=bind,source="$(pwd)/additional_sql",target=/docker-entrypoint-initdb.d \
+        my-prepopulated-image

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+. /entrypoint.sh
+
+_main() {
+	# if command starts with an option, prepend mysqld
+	if [ "${1:0:1}" = '-' ]; then
+		set -- mysqld "$@"
+	fi
+
+	# skip setup if they aren't running mysqld or want an option that stops mysqld
+	if [ "$1" = 'mysqld' ] && ! _mysql_want_help "$@"; then
+		mysql_note "Entrypoint script for MySQL Server ${MYSQL_VERSION} started."
+
+		mysql_check_config "$@"
+		# Load various environment variables
+		docker_setup_env "$@"
+		docker_create_db_directories
+
+		# If container is started as root user, restart as dedicated mysql user
+		if [ "$(id -u)" = "0" ]; then
+			mysql_note "Switching to dedicated user 'mysql'"
+			exec gosu mysql "$BASH_SOURCE" "$@"
+		fi
+
+		# there's no database, so it needs to be initialized
+        docker_verify_minimum_env
+
+        # check dir permissions to reduce likelihood of half-initialized database
+        ls /docker-entrypoint-initdb.d/ > /dev/null
+
+        [ -z "$DATABASE_ALREADY_EXISTS" ] && docker_init_database_dir "$@" || mysql_note "Skipping docker_init_database_dir"
+        mysql_note "Starting temporary server"
+        docker_temp_server_start "$@"
+        mysql_note "Temporary server started."
+        [ -z "$DATABASE_ALREADY_EXISTS" ] && docker_setup_db || mysql_note "Skipping docker_setup_db"
+        docker_process_init_files /docker-entrypoint-initdb.d/*
+
+        mysql_expire_root_user
+
+        mysql_note "Stopping temporary server"
+        docker_temp_server_stop
+        mysql_note "Temporary server stopped"
+
+        echo
+        mysql_note "MySQL init process done. Ready for start up."
+        echo
+	fi
+	[ -z $DONT_START_MYSQLD ] && exec "$@" || mysql_note "not running $1"
+}
+
+# If we are sourced from elsewhere, don't perform any further actions
+if ! _is_sourced; then
+	_main "$@"
+fi


### PR DESCRIPTION
I have modified the main function in the entrypoint so that if the db has already been initialized it can 
still initialize additional things mounted into /docker-entrypoint-initdb.d.
the mysql version i am using is 5, not latest, though I dont know of any reason it wouldnt work with latest